### PR TITLE
fix: use docs.utilbot.co as the docs site URL

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -5,7 +5,7 @@ import nimbus, { defineConfig as defineNimbusConfig } from "@cloudflare/nimbus-d
 import { tableScroll } from "@cloudflare/nimbus-docs/markdown";
 
 const nimbusConfig = defineNimbusConfig({
-	site: "https://utilbot.info",
+	site: "https://docs.utilbot.co",
 	title: "Utilbot Docs",
 	description: "Documentation, commands, and changelog for the Utilbot Discord bot.",
 	locale: "en",
@@ -60,7 +60,7 @@ const nimbusConfig = defineNimbusConfig({
 });
 
 export default defineConfig({
-	site: "https://utilbot.info",
+	site: "https://docs.utilbot.co",
 	output: "static",
 	vite: {
 		plugins: [tailwindcss()],


### PR DESCRIPTION
## Summary
- Update the Nimbus and Astro `site` config to `https://docs.utilbot.co`, replacing the stale `utilbot.info` domain
- Fixes canonical URLs and the "Open as Markdown" links, which were pointing at the wrong domain

## Why
`docs.utilbot.co` is the actual deployed domain (per the route pattern in `wrangler.jsonc`), but the site config still referenced `utilbot.info`, so generated canonical/markdown links were wrong.

## Test plan
- [ ] Build the site and confirm generated canonical URLs use `docs.utilbot.co`
- [ ] Verify "Open as Markdown" links resolve correctly on a deployed preview