### PR TITLE
docs: sync command reference with current bot interactions

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -43,6 +43,21 @@ const nimbusConfig = defineNimbusConfig({
 						autogenerate: { directory: "commands/rank" },
 					},
 					{
+						label: "Giveaways",
+						collapsed: true,
+						autogenerate: { directory: "commands/giveaways" },
+					},
+					{
+						label: "Fun",
+						collapsed: true,
+						autogenerate: { directory: "commands/fun" },
+					},
+					{
+						label: "Misc",
+						collapsed: true,
+						autogenerate: { directory: "commands/misc" },
+					},
+					{
 						label: "Moderators",
 						collapsed: true,
 						autogenerate: { directory: "commands/moderators" },

--- a/src/content/docs/commands/admins/log.md
+++ b/src/content/docs/commands/admins/log.md
@@ -4,32 +4,109 @@ sidebar:
   order: 11
 ---
 
-## Command
-
-```txt
-/log <enable/disable> [channel]
-```
-
 ## Description
 
-Sets the Log channel where the logs should be posted. By using 'disable' you can disable this feature.
+Manages the Log feature. Logging channels can each be configured with their own set of event types to log.
 
 ## Permission
 
 `ADMINISTRATOR`
 
-## Arguments
+---
+
+## Channels: List
+
+```txt
+/log channels list
+```
+
+Lists all channels currently configured for logging.
 
 | Name | Type | Description | Sample Data |
 | ---- | ---- | ----------- | ----------- |
-| channel | CHANNEL | The channel, where the logs should be posted | #logs |
+|      |      |             | None        |
 
-## Sample Response
+---
 
-### Enable
+## Channels: Add
 
-![Image](https://cdn.utilbot.co/2021-06-03_1c13a3e0-645d-4ede-b8f2-55e31aa201df.png)
+```txt
+/log channels add <channel>
+```
 
-### Disable
+Adds a channel for logging. After adding it, select the event types to log for that channel.
 
-![Image](https://cdn.utilbot.co/2021-06-03_d298856b-328c-4937-99f7-c643d89f98e6.png)
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+| channel | Channel (Text/News) | The channel to add | #logs |
+
+---
+
+## Channels: Edit
+
+```txt
+/log channels edit <channel>
+```
+
+Edits which event types are logged to an already configured channel.
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+| channel | Channel (Text/News) | The channel to edit | #logs |
+
+---
+
+## Channels: Remove
+
+```txt
+/log channels remove <channel>
+```
+
+Removes a channel from logging.
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+| channel | Channel (Text/News) | The channel to remove | #logs |
+
+---
+
+## Ignore: Add / Remove User
+
+```txt
+/log ignore add-user <user>
+/log ignore remove-user <user>
+```
+
+Adds or removes a user from the ignore list, so their actions are not logged.
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+| user | User | The user to ignore / stop ignoring | @HerrTxbias |
+
+---
+
+## Ignore: Add / Remove Channel
+
+```txt
+/log ignore add-channel <channel>
+/log ignore remove-channel <channel>
+```
+
+Adds or removes a channel from the ignore list, so events in it are not logged.
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+| channel | Channel | The channel to ignore / stop ignoring | #bot-spam |
+
+---
+
+## Log Event Types
+
+When adding or editing a logging channel, you can select any combination of the following event types:
+
+- Channel Changes
+- Member Join / Leave
+- Member Role Changes
+- Message Logs
+- Message Logs (Detailed)
+- Misc

--- a/src/content/docs/commands/admins/teamlist.mdx
+++ b/src/content/docs/commands/admins/teamlist.mdx
@@ -2,7 +2,14 @@
 title: 'Teamlist'
 sidebar:
   order: 8
+  badge:
+    text: Discontinued
+    variant: danger
 ---
+
+<Aside type="danger" title="Command Discontinued">
+The Teamlist feature has been disabled for all guilds and this command is no longer available.
+</Aside>
 
 ## Command
 

--- a/src/content/docs/commands/command-overview.md
+++ b/src/content/docs/commands/command-overview.md
@@ -23,7 +23,23 @@ sidebar:
 
 ### Rank
 
+- [Rank](/commands/rank/rank)
 - [Leaderboard](/commands/rank/leaderboard)
+
+### Giveaways
+
+- [Giveaway](/commands/giveaways/giveaway)
+
+### Fun
+
+- [Starboard](/commands/fun/starboard)
+
+### Misc
+
+- [Quote](/commands/misc/quote)
+- [Tag](/commands/misc/tag)
+- [Tag Management](/commands/misc/tag-management)
+- [Developer](/commands/misc/developer)
 
 ### Moderators
 

--- a/src/content/docs/commands/fun/starboard.mdx
+++ b/src/content/docs/commands/fun/starboard.mdx
@@ -1,0 +1,60 @@
+---
+title: 'Starboard'
+sidebar:
+  order: 0
+---
+
+## Description
+
+<Aside type="note">
+You may need to enable this feature via the Website.
+</Aside>
+
+Creates a starboard to save your favorite messages with a ⭐️. When a message reaches the configured amount of star reactions, it gets posted to the starboard channel.
+
+## Permission
+
+`ADMINISTRATOR`
+
+---
+
+## Setup
+
+```txt
+/starboard setup <channel> [amount]
+```
+
+Sets up (or reconfigures) the starboard.
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+| channel | Channel (Text/News) | The channel to post starred messages to | #starboard |
+| amount | Integer | The amount of stars needed to save a message. Min 1, max 100 | 3 |
+
+---
+
+## Config
+
+```txt
+/starboard config
+```
+
+Shows the current starboard configuration.
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+|      |      |             | None        |
+
+---
+
+## Disable
+
+```txt
+/starboard disable
+```
+
+Disables the starboard and restores all default settings.
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+|      |      |             | None        |

--- a/src/content/docs/commands/general/help.mdx
+++ b/src/content/docs/commands/general/help.mdx
@@ -9,20 +9,8 @@ sidebar:
 
 ## Command
 
-**Slash Command**
-
 ```txt
 /utilbot help
-```
-
-<Aside type="caution" title="Command Deprecated">
-The old help command is still available but will be removed in the near future. Please use the new slash command.
-</Aside>
-
-**Old Command**
-
-```txt
-p!help / p!h
 ```
 
 ## Description

--- a/src/content/docs/commands/giveaways/giveaway.mdx
+++ b/src/content/docs/commands/giveaways/giveaway.mdx
@@ -1,0 +1,84 @@
+---
+title: 'Giveaway'
+sidebar:
+  order: 0
+---
+
+## Description
+
+<Aside type="note">
+You may need to enable this feature via the Website.
+</Aside>
+
+Manages Giveaways.
+
+## Permission
+
+`MANAGE_GUILD`
+
+---
+
+## Create
+
+```txt
+/giveaway create <channel> <winners> [no-async]
+```
+
+Opens a modal (Title, Description, Duration) after selecting the channel and winner count. Submitting the modal publishes the giveaway.
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+| channel | Channel (Text/Announcement) | The channel to create the giveaway in | #giveaways |
+| winners | Integer | The number of winners to pick. Min 1, max 100 | 1 |
+| no-async | Boolean | Disables the experimental async mode | false |
+
+The modal fields are:
+
+| Field | Description | Sample Data |
+| ----- | ----------- | ----------- |
+| Title | The title of the giveaway | Nitro Giveaway |
+| Description | An optional description. Max 2048 characters | Win a month of Discord Nitro! |
+| Duration | Duration relative from now. Example: "1d", "1h", "1m", "1s" | 1d |
+
+---
+
+## End
+
+```txt
+/giveaway end <giveaway>
+```
+
+Ends a giveaway early and announces the winners.
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+| giveaway | String | The giveaway to end. Supports autocomplete | Nitro Giveaway |
+
+---
+
+## Reroll
+
+```txt
+/giveaway reroll <giveaway> [winners]
+```
+
+Rerolls the winner(s) of an already ended giveaway.
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+| giveaway | String | The giveaway to reroll. Supports autocomplete | Nitro Giveaway |
+| winners | Integer | The amount of winners to reroll. Default: all winners. Min 1, max 100 | 1 |
+
+---
+
+## List
+
+```txt
+/giveaway list
+```
+
+Lists all active giveaways of the guild.
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+|      |      |             | None        |

--- a/src/content/docs/commands/misc/developer.md
+++ b/src/content/docs/commands/misc/developer.md
@@ -1,0 +1,26 @@
+---
+title: 'Developer'
+sidebar:
+  order: 3
+---
+
+## Command
+
+```txt
+/developer buildoverride <url> [ephemeral]
+```
+
+## Description
+
+Useful commands for developers. Currently only supports decoding Discord Build Override links.
+
+## Permission
+
+`none`
+
+## Arguments
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+| url | String | The complete URL of the Build Override | https://discord.com/__development/link... |
+| ephemeral | Boolean | Send the message as an ephemeral message. Default: true | false |

--- a/src/content/docs/commands/misc/quote.md
+++ b/src/content/docs/commands/misc/quote.md
@@ -1,0 +1,25 @@
+---
+title: 'Quote'
+sidebar:
+  order: 0
+---
+
+## Command
+
+```txt
+/quote <url>
+```
+
+## Description
+
+Quotes a message from another channel into the current channel via a webhook, mimicking the original author's name and avatar.
+
+## Permission
+
+`none`
+
+## Arguments
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+| url | String | The full URL of the message to quote | https://discord.com/channels/.../.../... |

--- a/src/content/docs/commands/misc/tag-management.md
+++ b/src/content/docs/commands/misc/tag-management.md
@@ -1,0 +1,94 @@
+---
+title: 'Tag Management'
+sidebar:
+  order: 2
+---
+
+## Description
+
+Manages guild tags, which can be called with [`/tag`](/commands/misc/tag). Creating, deleting, and aliasing tags requires the `MANAGE_MESSAGES` permission; listing tags and aliases is available to everyone.
+
+## Permission
+
+`MANAGE_MESSAGES` (for `create`, `delete`, `alias-create`, `alias-delete`) / `none` (for `list`, `alias-list`)
+
+---
+
+## Create
+
+```txt
+/tag-management create <name> <content>
+```
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+| name | String | The name of the tag. Max 100 characters | rules |
+| content | String | The content of the tag. Max 2000 characters | Please read #rules before chatting! |
+
+---
+
+## Delete
+
+```txt
+/tag-management delete <name>
+```
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+| name | String | The name of the tag to delete. Supports autocomplete | rules |
+
+---
+
+## List
+
+```txt
+/tag-management list
+```
+
+Lists all tags of the guild.
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+|      |      |             | None        |
+
+---
+
+## Alias Create
+
+```txt
+/tag-management alias-create <tag> <alias>
+```
+
+Creates an alias for an existing tag. Aliases cannot shadow an existing tag name.
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+| tag | String | The name of the tag to alias. Supports autocomplete | rules |
+| alias | String | The alias name. Max 100 characters | regeln |
+
+---
+
+## Alias Delete
+
+```txt
+/tag-management alias-delete <tag> <alias>
+```
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+| tag | String | The name of the tag. Supports autocomplete | rules |
+| alias | String | The alias to delete. Supports autocomplete | regeln |
+
+---
+
+## Alias List
+
+```txt
+/tag-management alias-list <tag>
+```
+
+Lists all aliases of a tag.
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+| tag | String | The name of the tag. Supports autocomplete | rules |

--- a/src/content/docs/commands/misc/tag.md
+++ b/src/content/docs/commands/misc/tag.md
@@ -1,0 +1,25 @@
+---
+title: 'Tag'
+sidebar:
+  order: 1
+---
+
+## Command
+
+```txt
+/tag <name>
+```
+
+## Description
+
+Calls a guild tag and sends its content. Tags (and their aliases) are managed with [`/tag-management`](/commands/misc/tag-management).
+
+## Permission
+
+`none`
+
+## Arguments
+
+| Name | Type | Description | Sample Data |
+| ---- | ---- | ----------- | ----------- |
+| name | String | The name of the tag to call. Supports autocomplete | rules |

--- a/src/content/docs/commands/moderators/ban.md
+++ b/src/content/docs/commands/moderators/ban.md
@@ -7,7 +7,7 @@ sidebar:
 ## Command
 
 ```txt
-/mod ban <user> [message_delete_days] [reason]
+/mod ban <user> [delete_message_days] [reason]
 ```
 
 ## Description
@@ -23,7 +23,7 @@ Bans a Member.
 | Name | Type | Description | Sample Data |
 | ---- | ---- | ----------- | ----------- |
 | user | User | A user (ID should also work) | @HerrTxbias |
-| message_delete_days | Integer | Delete messages of the user for the past x days | 4 |
+| delete_message_days | Choice (0-7) | Number of days of the user's messages to delete | 4 Days |
 | reason | String | The ban reason | Writing rude things |
 
 ## Sample Response

--- a/src/content/docs/commands/moderators/clear.md
+++ b/src/content/docs/commands/moderators/clear.md
@@ -18,7 +18,7 @@ Deletes all, or a specific amount of messages in the Chat.
 ## Arguments
 | Name | Type | Description | Sample Data |
 | ---- | ---- | ----------- | ----------- |
-| `message_num` | number | The amount of messages to delete. Argument is optional. | `20` |
+| `message_num` | number | The amount of messages to delete. Min 1, max 100. Default: 100 | `20` |
 
 ## Sample Response
 ![Image](https://cdn.utilbot.co/2021-05-28_38b3a317-4396-48bb-819e-f9e884552bb8.png)

--- a/src/content/docs/commands/moderators/warn.md
+++ b/src/content/docs/commands/moderators/warn.md
@@ -10,10 +10,10 @@ sidebar:
 ```
 
 ## Description
-Warns a Member.
+Warns a Member. Requires the warn feature to be enabled via [`/warns enable`](/commands/admins/warns).
 
 ## Permission
-`KICK_MEMBERS`
+`MODERATE_MEMBERS`
 
 ## Arguments
 | Name | Type | Description | Sample Data |

--- a/src/content/docs/commands/poll/create-poll.mdx
+++ b/src/content/docs/commands/poll/create-poll.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 ## Command
 ```
-/poll create <title> <duration> <answers>
+/poll create
 ```
 
 ## Description
@@ -14,17 +14,20 @@ sidebar:
 You may need to enable this feature via the Website.
 </Aside>
 
-Creates a Poll.
+Opens a modal to create a Poll. Fill in the fields and submit the modal to publish the poll.
 
 ## Permission
 `MANAGE_MESSAGES`
 
 ## Arguments
-| Name | Type | Description | Sample Data |
-| ---- | ---- | ----------- | ----------- |
-| question | String | The Poll Title, could be like a Question. | Title of the Poll |
-| duration | String | Duration of the Poll. Example: "1h" or "1d" | 1h |
-| answer | String | The possible Answers to the Poll. Separate with "\|". Max 80 Chars per Answer. Minimum 2 Answers. Maximum 25 Answers. Example: "Answer 1\|Answer 2\|Answer 3" | Good |
+
+This command opens a modal instead of taking inline options:
+
+| Field | Description | Sample Data |
+| ----- | ----------- | ----------- |
+| Title | The Poll title, could be like a question. Min 5, max 200 characters. | Title of the Poll |
+| Duration | Duration of the Poll. Example: "1h" or "1d" | 1h |
+| Answers | The possible answers to the Poll, one per line. Max 25 answers, max 80 characters per answer. | Answer 1\nAnswer 2\nAnswer 3 |
 
 ## Sample Response
 ![Image](https://cdn.utilbot.co/2022-02-05_22-23-21_f2ab64e6-3699-4ca8-b44a-c2e5ff54183c.png)

--- a/src/content/docs/commands/rank/rank.mdx
+++ b/src/content/docs/commands/rank/rank.mdx
@@ -1,13 +1,13 @@
 ---
-title: 'Leaderboard'
+title: 'Rank'
 sidebar:
-  order: 1
+  order: 0
 ---
 
 ## Command
 
 ```txt
-/leaderboard
+/rank [target] [ephemeral]
 ```
 
 ## Description
@@ -16,7 +16,7 @@ sidebar:
 You may need to enable this feature via the Website.
 </Aside>
 
-Shows the Server Leaderboard.
+Shows the Rank Card for you, or another Member.
 
 ## Permission
 
@@ -26,8 +26,5 @@ Shows the Server Leaderboard.
 
 | Name | Type | Description | Sample Data |
 | ---- | ---- | ----------- | ----------- |
-|      |      |             | None        |
-
-## Sample Response
-
-![Image](https://cdn.utilbot.co/Discord_jC6aohohJT.png)
+| target | User | The User to show the Rank Card for. Default: yourself | @HerrTxbias |
+| ephemeral | Boolean | Send the message as an ephemeral message | true |


### PR DESCRIPTION
## Summary

Cross-checked every documented command page against the bot's actual `chatInputCommands` source (`services/bot/src/interactions/chatInputCommands`) and brought the docs back in sync.

**Fixed inaccuracies:**
- `/mod ban`: option name was `message_delete_days`, actual is `delete_message_days` (a 0-7 day choice list, not free-form)
- `/mod warn`: permission was listed as `KICK_MEMBERS`, actual is `MODERATE_MEMBERS`; noted it requires `/warns enable`
- `/utilbot help`: removed the deprecated `p!help`/`p!h` prefix-command section — no prefix commands exist in the codebase anymore
- `/poll create`: now documented as the modal it actually is (Title/Duration/Answers, one answer per line), not inline pipe-separated options
- `/log`: full rewrite — the old `/log <enable/disable> [channel]` is gone, replaced by `/log channels list|add|edit|remove` and `/log ignore add-user|remove-user|add-channel|remove-channel`
- `/teamlist`: marked Discontinued — the command carries `disabled: true` in source and was migrated off for all guilds

**Added missing command pages** (present in source but previously undocumented):
- `/rank`
- `/giveaway` (new "Giveaways" sidebar category)
- `/starboard` (new "Fun" sidebar category)
- `/quote`, `/tag`, `/tag-management`, `/developer` (new "Misc" sidebar category)

**Intentionally left undocumented:** `/guild` (still a WIP placeholder returning "soon™"), and all `botdev`/context-menu bookmark commands (guild-restricted to the internal support server, not public-facing).

## Test plan

- [x] `astro check` — 0 errors
- [x] `astro build` — succeeds, MDX/internal-link lint passes
- [x] Spot-checked new pages (`/commands/giveaways/giveaway/`, `/commands/rank/rank/`, `/commands/misc/tag-management/`, `/commands/admins/log/`) render correctly via `astro preview`